### PR TITLE
Update DebugNode to full NR capabilities

### DIFF
--- a/nodered.js
+++ b/nodered.js
@@ -342,6 +342,21 @@ class DebugNode extends Node {
 		this.#statusVal = config.statusVal;
 	}
 	onMessage(msg) {
+		
+		// Feed msg back to the editor.
+		let input = {
+			input: {
+				...msg,
+				source: {
+					id: this.id,
+					type: this.constructor.type,
+					name: this.name,
+				}	
+			}
+		}
+		trace.left(JSON.stringify(input));
+
+		// Process msg for xsbug
 		let value = this.#getter(msg);
 
 		if (this.#console) {
@@ -362,16 +377,17 @@ class DebugNode extends Node {
 			}
 			trace.right(JSON.stringify(value));
 		}
-		if (this.#toStatus) {
-			// This is nothing but a very simplistic copy of what the NR node really does...
-			// ToDo: Move closer to the NR debug node!
-			const statusVal = this.#statusVal(msg);
-			if (statusVal) {
-				const fill = "grey";
-				const shape = "dot";
-				this.status({fill, shape, text: statusVal})
-			}
-		}
+
+		// if (this.#toStatus) {
+		// 	// This is nothing but a very simplistic copy of what the NR node really does...
+		// 	// ToDo: Move closer to the NR debug node!
+		// 	const statusVal = this.#statusVal(msg);
+		// 	if (statusVal) {
+		// 		const fill = "grey";
+		// 		const shape = "dot";
+		// 		this.status({fill, shape, text: statusVal})
+		// 	}
+		// }
 	}
 
 	static type = "debug"


### PR DESCRIPTION
This is a small (but capable) change to the DebugNode: It emits the incoming `msg` back to the plugin. The `input` flag tells the plugin to feed this `msg` into the dedicated node - as if the flow would run in its standard environment.

This idea has some limitations - of course.

For the DebugNode it yet offers several advantages:

- There's no need for the MCU to handle all the different aspects that are managed in standard NR DebugNode; the `this.#toStatus` code e.g. is obsolete then.
- There's no need to flag `jsonata` as `NotImplemented`. It's not present on the MCU - but in the editor. Thus it should be enough to log a compile time info stating this detail.
- Less Code on the MCU.
- Full capabilities at (almost) no effort - in the NR editor.

That said, the output of the DebugNode could be further optimized to meet the demands of `xsbug` - without the need to respect NR standard requirements.

Additionally I would vote to consider a dedicated communication channel (back to the editor) as alternative to the `trace` interface. There's currently a lot of noise in the sidebar due to all these messages sent...