### PR TITLE
Inject sensor manifest into plugins build process

### DIFF
--- a/nodes/sensor/sensor.html
+++ b/nodes/sensor/sensor.html
@@ -406,6 +406,14 @@
   			this.platform = platformKey;
   			this.module = moduleKey;
 			this.options = options;
+
+			// define data to be injected by the plugin
+			if (this._mcu) {
+				let d = database.sensor[moduleKey].driver;
+				if (d) {
+					this._mcu.include = [d];
+				}
+			}
      	},
     });
 </script>


### PR DESCRIPTION
With a [small change](https://github.com/ralphwetzel/node-red-mcu-plugin/commit/ba73e5394800ed1c602cd4d88fe3322bd288cde7) made to the plugin it's now possible to define - on a per node scope - data that shall be added to the flows `manifest.json`.

The PR operates on this feature to inject the sensors driver manifest into the plugins build process.