### PR TITLE
Using NeoPixel with M5StackCore2 Bottom2 or with M5StackCore2AWS

### DIFF
--- a/nodes/rpi-neopixels/manifest.json
+++ b/nodes/rpi-neopixels/manifest.json
@@ -15,6 +15,23 @@
 			},
 			"preload": "rpi-neopixels"
 		},
+		"esp32/m5stack_core2":{
+			"defines": {
+				"neopixel": {
+					"length": 10,
+					"order": "#GRB",
+					"pin": 25
+				}
+			},
+			"modules": {
+				"*": [
+					"./rpi-neopixels",
+					"$(MODULES)/drivers/neopixel/*",
+					"$(MODULES)/drivers/neopixel/esp32/*"
+				]
+			},
+			"preload": ["neopixel","rpi-neopixels"]
+		},
 		"pico": {
 			"include": "$(MODULES)/drivers/neopixel/manifest.json",
 			"modules": {


### PR DESCRIPTION
hello,
I added the Sub Platform of Mainifest.json in order to use NeoPixel in M5StackCore2 with Bottom2 and M5StackCore2AWS.
https://docs.m5stack.com/en/core/core2_for_aws
https://docs.m5stack.com/en/base/m5go_bottom2
Thank you.