### PR TITLE
fix neopixels (when arguments are 4 and 5)

### DIFF
--- a/nodes/neopixels/mcu_neopixels.js
+++ b/nodes/neopixels/mcu_neopixels.js
@@ -250,14 +250,14 @@ class NeopixelsNode extends Node {
 				case 4:	// set nth pixel: n, r, g, b
 					if (!this.#mode.startsWith("p"))
 						return void done();
-					this.setPixel(parts[0], this.#np.makeRGB(parts[1], parts[2], parts[3]));
+					this.setPixel(parts[0]-1, this.#np.makeRGB(parts[1], parts[2], parts[3]));
 					break;
 
 				case 5: {		// set pixels x through y: x, y, r, g, b
 					if (!this.#mode.startsWith("p"))
 						return void done();
 					const x = parseInt(parts[0]), y = parseInt(parts[1]);
-					this.fill(this.#np.makeRGB(parts[2], parts[3], parts[4]), x, y);
+					this.fill(this.#np.makeRGB(parts[2], parts[3], parts[4]), x-1, y);
 					} break;
 				
 				default:

--- a/nodes/neopixels/mcu_neopixels.js
+++ b/nodes/neopixels/mcu_neopixels.js
@@ -257,7 +257,7 @@ class NeopixelsNode extends Node {
 					if (!this.#mode.startsWith("p"))
 						return void done();
 					const x = parseInt(parts[0]), y = parseInt(parts[1]);
-					this.fill(this.#np.makeRGB(parts[2], parts[3], parts[4]), x, y - x);
+					this.fill(this.#np.makeRGB(parts[2], parts[3], parts[4]), x, y);
 					} break;
 				
 				default:


### PR DESCRIPTION
with four arguments
For "msg.payload=[6,0,255,0]", the 7th and subsequent LEDs were lit. Fixed so that the 6th and subsequent LEDs light up.

with 5 arguments
When "msg.payload=[6,10,0,255,0]", only the 7th LED was lit. Changed to light up from 6th to 10th.