### PR TITLE
Fixed I2C can't connect

### DIFF
--- a/nodes/mcu/i2c/manifest.json
+++ b/nodes/mcu/i2c/manifest.json
@@ -1,6 +1,6 @@
 {
 	"modules": {
-		"*": "./mcu_i2c"
+		"*": "./i2c"
 	},
-	"preload": "mcu_i2c"
+	"preload": "i2c"
 }


### PR DESCRIPTION
Fixed I2C not connecting when using an I2C node, showing "[object Object]" in the xsbug log.
