### PR TITLE
Fix Wi-Fi connection failure in standalone mode (no debugger)

### DIFF
--- a/setupwifi.js
+++ b/setupwifi.js
@@ -23,6 +23,7 @@ import Time from "time";
 import Timer from "timer";
 import Modules from "modules";
 import WiFi from "embedded:network/interface/wifi";
+import SNTP from "sntp";
 
 export default function (done) {
 	const modconfig = Modules.has("mod/config") ? Modules.importNow("mod/config") : {};
@@ -54,7 +55,7 @@ export default function (done) {
 
 			trace(`IP address ${this.address}\n`);
 			Timer.schedule(this.reconnect);		// unschedule
-			if (!config.sntp || (Date.now() > 1672722071_000)) {
+			if (!sntp || (Date.now() > 1672722071_000)) {
 				const d = done;
 				done = undefined
 				return d?.();


### PR DESCRIPTION
### Situation
`import SNTP from "sntp"` was removed in ab8024b, apparently in preparation for migrating to the ECMA-419 NTP class. However, since that migration is not yet practical, the removal causes a crash in standalone mode when SNTP is needed.

### Fix
This PR restores the `import SNTP from "sntp"` statement and corrects the `config.sntp` reference as a temporary measure until the ECMA-419 NTP class migration is ready.